### PR TITLE
Add TypeScript Interface

### DIFF
--- a/android/src/main/java/com/lytics/react_native/LyticsModule.kt
+++ b/android/src/main/java/com/lytics/react_native/LyticsModule.kt
@@ -182,22 +182,14 @@ class LyticsModule(reactContext: ReactApplicationContext) :
     // Personalization
 
     @ReactMethod
-    fun getProfile(promise: Promise) {
-        getProfile(
-            identifier = null,
-            promise = promise
-        )
-    }
-
-    @ReactMethod
-    fun getProfile(name: String, value: String, promise: Promise) {
-        getProfile(
-            identifier = EntityIdentifier(name = name, value = value),
-            promise = promise
-        )
-    }
-
-    private fun getProfile(identifier: EntityIdentifier?, promise: Promise) {
+    fun getProfile(name: String? = null, value: String? = null, promise: Promise) {
+        var identifier: EntityIdentifier? = null
+        if (name != null && value != null) {
+            identifier = EntityIdentifier(
+                name = name,
+                value = value
+            )
+        }
         scope.launch {
             promise.resolve(Lytics.getProfile(identifier)?.toReadableMap())
         }

--- a/android/src/main/java/com/lytics/react_native/LyticsModule.kt
+++ b/android/src/main/java/com/lytics/react_native/LyticsModule.kt
@@ -66,7 +66,7 @@ class LyticsModule(reactContext: ReactApplicationContext) :
         val requestTimeout =
             options.getDoubleOrNull("networkRequestTimeout") ?: DEFAULT_NETWORK_REQUEST_TIMEOUT
         val logLevel =
-            options.getIntOrNull("logLevel")?.let { LogLevel::class.fromLelvelOrNull(it) }
+            options.getIntOrNull("logLevel")?.let { LogLevel::class.fromLevelOrNull(it) }
                 ?: LogLevel.NONE
 
         val config = LyticsConfiguration(

--- a/android/src/main/java/com/lytics/react_native/LyticsModule.kt
+++ b/android/src/main/java/com/lytics/react_native/LyticsModule.kt
@@ -54,7 +54,7 @@ class LyticsModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun user(promise: Promise) {
-        promise.resolve(Lytics.currentUser?.toHashMap())
+        promise.resolve(Lytics.currentUser?.toReadableMap())
     }
 
     // Configuration
@@ -199,7 +199,7 @@ class LyticsModule(reactContext: ReactApplicationContext) :
 
     private fun getProfile(identifier: EntityIdentifier?, promise: Promise) {
         scope.launch {
-            promise.resolve(Lytics.getProfile(identifier)?.toHashMap())
+            promise.resolve(Lytics.getProfile(identifier)?.toReadableMap())
         }
     }
 

--- a/android/src/main/java/com/lytics/react_native/LyticsModule.kt
+++ b/android/src/main/java/com/lytics/react_native/LyticsModule.kt
@@ -66,7 +66,7 @@ class LyticsModule(reactContext: ReactApplicationContext) :
         val requestTimeout =
             options.getDoubleOrNull("networkRequestTimeout") ?: DEFAULT_NETWORK_REQUEST_TIMEOUT
         val logLevel =
-            options.getString("logLevel")?.let { LogLevel::class.byNameIgnoreCaseOrNull(it) }
+            options.getIntOrNull("logLevel")?.let { LogLevel::class.fromLelvelOrNull(it) }
                 ?: LogLevel.NONE
 
         val config = LyticsConfiguration(

--- a/android/src/main/java/com/lytics/react_native/LyticsModule.kt
+++ b/android/src/main/java/com/lytics/react_native/LyticsModule.kt
@@ -60,47 +60,56 @@ class LyticsModule(reactContext: ReactApplicationContext) :
     // Configuration
 
     @ReactMethod
-    fun start(apiToken: String, options: ReadableMap) {
-        val uploadInterval = options.getDoubleOrNull("uploadInterval") ?: DEFAULT_UPLOAD_INTERVAL
-        val sessionTimeout = options.getDoubleOrNull("sessionTimeout") ?: DEFAULT_SESSION_TIMEOUT
+    fun start(configuration: ReadableMap, promise: Promise) {
+        val apiToken = configuration.getString("apiToken")
+        if (apiToken == null) {
+            promise.reject("MISSING_API_TOKEN", "The API token is missing in the configuration.")
+            return
+        }
+        val uploadInterval =
+            configuration.getDoubleOrNull("uploadInterval") ?: DEFAULT_UPLOAD_INTERVAL
+        val sessionTimeout =
+            configuration.getDoubleOrNull("sessionTimeout") ?: DEFAULT_SESSION_TIMEOUT
         val requestTimeout =
-            options.getDoubleOrNull("networkRequestTimeout") ?: DEFAULT_NETWORK_REQUEST_TIMEOUT
+            configuration.getDoubleOrNull("networkRequestTimeout")
+                ?: DEFAULT_NETWORK_REQUEST_TIMEOUT
         val logLevel =
-            options.getIntOrNull("logLevel")?.let { LogLevel::class.fromLevelOrNull(it) }
+            configuration.getIntOrNull("logLevel")?.let { LogLevel::class.fromLevelOrNull(it) }
                 ?: LogLevel.NONE
 
         val config = LyticsConfiguration(
             apiKey = apiToken,
-            defaultStream = options.getString("defaultStream") ?: DEFAULT_STREAM,
-            primaryIdentityKey = options.getString("primaryIdentityKey")
+            defaultStream = configuration.getString("defaultStream") ?: DEFAULT_STREAM,
+            primaryIdentityKey = configuration.getString("primaryIdentityKey")
                 ?: LyticsConfiguration.DEFAULT_PRIMARY_IDENTITY_KEY,
-            anonymousIdentityKey = options.getString("anonymousIdentityKey")
+            anonymousIdentityKey = configuration.getString("anonymousIdentityKey")
                 ?: LyticsConfiguration.DEFAULT_ANONYMOUS_IDENTITY_KEY,
-            defaultTable = options.getString("defaultTable")
+            defaultTable = configuration.getString("defaultTable")
                 ?: LyticsConfiguration.DEFAULT_ENTITY_TABLE,
-            requireConsent = options.getBooleanOrNull("requireConsent") ?: false,
-            autoTrackActivityScreens = options.getBooleanOrNull("autoTrackActivityScreens")
+            requireConsent = configuration.getBooleanOrNull("requireConsent") ?: false,
+            autoTrackActivityScreens = configuration.getBooleanOrNull("autoTrackActivityScreens")
                 ?: false,
-            autoTrackFragmentScreens = options.getBooleanOrNull("autoTrackFragmentScreens")
+            autoTrackFragmentScreens = configuration.getBooleanOrNull("autoTrackFragmentScreens")
                 ?: false,
-            autoTrackAppOpens = options.getBooleanOrNull("autoTrackAppOpens") ?: false,
-            maxQueueSize = options.getIntOrNull("maxQueueSize") ?: DEFAULT_MAX_QUEUE_SIZE,
-            maxUploadRetryAttempts = options.getIntOrNull("maxUploadRetryAttempts")
+            autoTrackAppOpens = configuration.getBooleanOrNull("autoTrackAppOpens") ?: false,
+            maxQueueSize = configuration.getIntOrNull("maxQueueSize") ?: DEFAULT_MAX_QUEUE_SIZE,
+            maxUploadRetryAttempts = configuration.getIntOrNull("maxUploadRetryAttempts")
                 ?: DEFAULT_MAX_UPLOAD_RETRY_ATTEMPTS,
-            maxLoadRetryAttempts = options.getIntOrNull("maxLoadRetryAttempts")
+            maxLoadRetryAttempts = configuration.getIntOrNull("maxLoadRetryAttempts")
                 ?: DEFAULT_MAX_LOAD_RETRY_ATTEMPTS,
             uploadInterval = TimeUnit.SECONDS.toMillis(uploadInterval.toLong()),
             sessionTimeout = TimeUnit.MINUTES.toMillis(sessionTimeout.toLong()),
             logLevel = logLevel,
-            sandboxMode = options.getBooleanOrNull("sandboxMode") ?: false,
-            collectionEndpoint = options.getString("collectionEndpoint")
+            sandboxMode = configuration.getBooleanOrNull("sandboxMode") ?: false,
+            collectionEndpoint = configuration.getString("collectionEndpoint")
                 ?: LyticsConfiguration.DEFAULT_COLLECTION_ENDPOINT,
-            entityEndpoint = options.getString("entityEndpoint")
+            entityEndpoint = configuration.getString("entityEndpoint")
                 ?: LyticsConfiguration.DEFAULT_ENTITY_ENDPOINT,
             networkRequestTimeout = TimeUnit.SECONDS.toMillis(requestTimeout.toLong()).toInt()
         )
 
         Lytics.init(context = context, configuration = config)
+        promise.resolve(null)
     }
 
     // Events

--- a/android/src/main/java/com/lytics/react_native/Util.kt
+++ b/android/src/main/java/com/lytics/react_native/Util.kt
@@ -29,8 +29,8 @@ fun ReadableMap.getIntOrNull(key: String): Int? {
     }
 }
 
-fun KClass<LogLevel>.byNameIgnoreCaseOrNull(level: String): LogLevel? {
-    return LogLevel.values().firstOrNull { it.name.equals(level, true) }
+fun KClass<LogLevel>.fromLelvelOrNull(level: Int): LogLevel? {
+    return LogLevel.values().firstOrNull { it.ordinal == level }
 }
 
 fun LyticsUser.toHashMap(): HashMap<String, Any?> {

--- a/android/src/main/java/com/lytics/react_native/Util.kt
+++ b/android/src/main/java/com/lytics/react_native/Util.kt
@@ -29,7 +29,7 @@ fun ReadableMap.getIntOrNull(key: String): Int? {
     }
 }
 
-fun KClass<LogLevel>.fromLelvelOrNull(level: Int): LogLevel? {
+fun KClass<LogLevel>.fromLevelOrNull(level: Int): LogLevel? {
     return LogLevel.values().firstOrNull { it.ordinal == level }
 }
 

--- a/example/ios/SdkExample/Info.plist
+++ b/example/ios/SdkExample/Info.plist
@@ -51,5 +51,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Your data will be used to deliver personalized ads to you.</string>
 </dict>
 </plist>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -30,17 +30,25 @@ export default function App() {
     <NavigationContainer>
       <Tab.Navigator>
         <Tab.Screen
-          name="Events"
+          name="EventsTab"
           component={EventsTabNavigator}
-          options={{ headerShown: false }}
+          options={{ headerShown: false, title: 'Events' }}
         />
         <Tab.Screen
-          name="Login"
+          name="LoginTab"
           component={LoginTabNavigator}
-          options={{ headerShown: false }}
+          options={{ headerShown: false, title: 'Login' }}
         />
-        <Tab.Screen name="Profile" component={ProfileScreen} />
-        <Tab.Screen name="Settings" component={SettingsScreen} />
+        <Tab.Screen
+          name="ProfileTab"
+          component={ProfileScreen}
+          options={{ title: 'Profile' }}
+        />
+        <Tab.Screen
+          name="SettingsTab"
+          component={SettingsScreen}
+          options={{ title: 'Settings' }}
+        />
       </Tab.Navigator>
     </NavigationContainer>
   );

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { start, hasStarted } from 'react-native-sdk';
+import { start, hasStarted, LogLevel } from 'react-native-sdk';
 
 import { EventsTabNavigator } from './navigation/EventsTabNavigator';
 import { LoginTabNavigator } from './navigation/LoginTabNavigator';
@@ -18,7 +18,9 @@ export default function App() {
 
   React.useEffect(() => {
     // Configure the SDK at startup
-    start(apiToken, {});
+    start(apiToken, {
+      logLevel: LogLevel.debug,
+    });
     hasStarted().then(setResult);
   }, []);
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { start, hasStarted, LogLevel } from 'react-native-sdk';
@@ -11,20 +11,20 @@ import { SettingsScreen } from './screens/Settings';
 const Tab = createBottomTabNavigator();
 
 export default function App() {
-  const [result, setResult] = React.useState<boolean | undefined>();
-
   // WARNING: this is not a safe way to store your API token!
   const apiToken = 'xxxxxx';
 
-  React.useEffect(() => {
+  useEffect(() => {
     // Configure the SDK at startup
-    start(apiToken, {
+    start({
+      apiToken: apiToken,
       logLevel: LogLevel.debug,
     });
-    hasStarted().then(setResult);
-  }, []);
 
-  console.log('hasStarted:', result);
+    hasStarted().then((result) => {
+      console.log('hasStarted:', result);
+    });
+  }, []);
 
   return (
     <NavigationContainer>

--- a/example/src/screens/EventDetail.tsx
+++ b/example/src/screens/EventDetail.tsx
@@ -1,11 +1,24 @@
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, Button } from 'react-native';
+import { screen, track } from 'react-native-sdk';
 
 import { styles } from '../components/Styles';
 
 export function EventDetailScreen() {
+  useEffect(() => {
+    console.log('Load Event Detail');
+    screen({
+      name: 'Event_Detail',
+      properties: { artistID: 123, eventID: 345 },
+    });
+  }, []);
+
   const handleBuy = () => {
     console.log('Buy');
+    track({
+      name: 'Buy_Tickets',
+      properties: { artistID: 123, eventID: 345 },
+    });
   };
 
   return (

--- a/example/src/screens/Events.tsx
+++ b/example/src/screens/Events.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { View, Text, Button } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { track } from 'react-native-sdk';
 
 import { styles } from '../components/Styles';
 import type { EventsStackParams } from '../navigation/EventsStackParams';
@@ -10,6 +11,7 @@ export function EventsScreen({
 }: NativeStackScreenProps<EventsStackParams, 'Events'>) {
   const handleSelect = () => {
     console.log('Select');
+    track({ name: 'Event_Tap', properties: { event: 'Event_Tap' } });
     navigation.navigate('EventDetail');
   };
 

--- a/example/src/screens/Login.tsx
+++ b/example/src/screens/Login.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { identify } from 'react-native-sdk';
 
 import { styles } from '../components/Styles';
 import type { LoginStackParams } from '../navigation/LoginStackParams';
@@ -13,6 +14,7 @@ export function LoginScreen({
 
   const handleLogin = () => {
     console.log('Login');
+    identify({ identifiers: { email: email } });
   };
 
   const handleRegister = () => {

--- a/example/src/screens/Profile.tsx
+++ b/example/src/screens/Profile.tsx
@@ -1,10 +1,25 @@
-import * as React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, ScrollView } from 'react-native';
+import { getProfile } from 'react-native-sdk';
 
 import { styles } from '../components/Styles';
 
 export function ProfileScreen() {
-  const [data, setData] = React.useState({});
+  const [data, setData] = useState({});
+
+  const loadProfile = async () => {
+    try {
+      const profile = await getProfile();
+      console.log('Profile:', profile);
+      setData(profile);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    loadProfile();
+  }, []);
 
   return (
     <View style={styles.container}>
@@ -13,7 +28,7 @@ export function ProfileScreen() {
         format:
       </Text>
       <ScrollView style={styles.scrollView}>
-        <Text>{JSON.stringify(data)}</Text>
+        <Text>{JSON.stringify(data, null, 2)}</Text>
       </ScrollView>
     </View>
   );

--- a/example/src/screens/Settings.tsx
+++ b/example/src/screens/Settings.tsx
@@ -1,16 +1,101 @@
-import * as React from 'react';
-import { View, Button } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Button, Text } from 'react-native';
+import {
+  disableTracking,
+  dispatch,
+  isOptedIn,
+  isTrackingEnabled,
+  optIn,
+  optOut,
+  requestTrackingAuthorization,
+  reset,
+  user,
+} from 'react-native-sdk';
 
 import { styles } from '../components/Styles';
 
 export function SettingsScreen() {
+  const [optedIn, setOptedIn] = useState(false);
+  const [trackingEnabled, setTrackingEnabled] = useState(false);
+  const [userProfile, setUserProfile] = useState({});
+
+  useEffect(() => {
+    isOptedIn().then((value) => {
+      console.log('isOptedIn:', value);
+      setOptedIn(value);
+    });
+    isTrackingEnabled().then((value) => {
+      console.log('isTrackingEnabled:', value);
+      setTrackingEnabled(value);
+    });
+    user().then((value) => {
+      console.log('user:', value);
+      setUserProfile(value);
+    });
+  }, []);
+
+  const handleOptInOrOut = () => {
+    if (optedIn) {
+      console.log('Opting out...');
+      optOut();
+    } else {
+      console.log('Opting in...');
+      optIn();
+    }
+
+    isOptedIn().then((value) => {
+      setOptedIn(value);
+    });
+  };
+
+  const handleTracking = () => {
+    if (trackingEnabled) {
+      console.log('Disabling tracking...');
+      disableTracking();
+
+      isTrackingEnabled().then((value) => {
+        setTrackingEnabled(value);
+      });
+    } else {
+      console.log('Enabling tracking...');
+      requestTrackingAuthorization().then((granted) => {
+        if (granted) {
+          console.log('Tracking Authorized');
+        } else {
+          console.log('Tracking Denied');
+        }
+
+        isTrackingEnabled().then((value) => {
+          setTrackingEnabled(value);
+        });
+      });
+    }
+  };
+
+  const handleDispatch = () => {
+    console.log('Dispatching...');
+    dispatch();
+  };
+
   const handleReset = () => {
-    console.log('Reset');
+    console.log('Reseting...');
+    reset();
   };
 
   return (
     <View style={styles.container}>
       <Button title="Reset Demo App" onPress={handleReset} />
+      <Button title="Dispatch Events" onPress={handleDispatch} />
+      <Button
+        title={optedIn ? 'Opt Out' : 'Opt In'}
+        onPress={handleOptInOrOut}
+      />
+      <Button
+        title={trackingEnabled ? 'Disable Tracking' : 'Enable Tracking'}
+        onPress={handleTracking}
+      />
+      <Text>User Profile:</Text>
+      <Text>{JSON.stringify(userProfile, null, 2)}</Text>
     </View>
   );
 }

--- a/example/src/screens/SignUp.tsx
+++ b/example/src/screens/SignUp.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button } from 'react-native';
 import CheckBox from '@react-native-community/checkbox';
+import {
+  consent,
+  identify,
+  requestTrackingAuthorization,
+} from 'react-native-sdk';
 
 import { styles } from '../components/Styles';
 
@@ -11,7 +16,34 @@ export function SignUpScreen() {
   const [acceptTerms, setAcceptTerms] = useState(false);
   const [allowPersonalization, setAllowPersonalization] = useState(false);
 
+  const sendInfo = () => {
+    identify({
+      identifiers: { email: email },
+      attributes: { name: name },
+    });
+    consent({
+      consent: {
+        documents: ['terms_aug_2022', 'privacy_may_2022'],
+        consented: true,
+      },
+    });
+  };
+
   const handleSignUp = () => {
+    if (allowPersonalization) {
+      console.log('Requesting Tracking Authorization...');
+      requestTrackingAuthorization().then((granted) => {
+        if (granted) {
+          console.log('Authorized');
+        } else {
+          console.log('Denied');
+        }
+
+        sendInfo();
+      });
+    } else {
+      sendInfo();
+    }
     console.log('Sign Up');
   };
 
@@ -58,7 +90,11 @@ export function SignUpScreen() {
           Improve my experience with better personalization (IDFA Demo).
         </Text>
       </View>
-      <Button title="Complete" onPress={handleSignUp} />
+      <Button
+        title="Complete"
+        onPress={handleSignUp}
+        disabled={!name || !password || !password || !acceptTerms}
+      />
     </View>
   );
 }

--- a/ios/LyticsBridge.mm
+++ b/ios/LyticsBridge.mm
@@ -18,7 +18,7 @@ RCT_EXTERN_METHOD(hasStarted:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(isOptedIn:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(isIDFAEnabled:(RCTPromiseResolveBlock)resolve
+RCT_EXTERN_METHOD(isTrackingEnabled:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(user:(RCTPromiseResolveBlock)resolve

--- a/ios/LyticsBridge.mm
+++ b/ios/LyticsBridge.mm
@@ -26,8 +26,9 @@ RCT_EXTERN_METHOD(user:(RCTPromiseResolveBlock)resolve
 
 #pragma mark - Configuration
 
-RCT_EXTERN_METHOD(start:(NSString *) apiToken
-                  configuration:(NSDictionary<NSString *,id> *) configuration)
+RCT_EXTERN_METHOD(start:(NSDictionary<NSString *,id> *) configuration
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 
 #pragma mark - Events
 

--- a/ios/LyticsBridge.mm
+++ b/ios/LyticsBridge.mm
@@ -57,9 +57,6 @@ RCT_EXTERN_METHOD(screen:(NSString *) stream
 
 #pragma mark - Personalization
 
-RCT_EXTERN_METHOD(getProfile:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(getProfile:(NSString *) identifierName
                   identifierValue:(NSString *) identifierValue
                   resolve:(RCTPromiseResolveBlock)resolve

--- a/ios/LyticsBridge.swift
+++ b/ios/LyticsBridge.swift
@@ -88,7 +88,9 @@ public final class LyticsBridge: NSObject {
                 lyticsConfig.anonymousIdentityKey = anonymousIdentityKey
             }
 
-            // skipping `.trackApplicationLifecycleEvents`
+            if let trackApplicationLifecycleEvents = configuration["trackApplicationLifecycleEvents"] as? Bool {
+                lyticsConfig.trackApplicationLifecycleEvents = trackApplicationLifecycleEvents
+            }
 
             if let uploadInterval = configuration["uploadInterval"] as? Double {
                 lyticsConfig.uploadInterval = uploadInterval

--- a/ios/LyticsBridge.swift
+++ b/ios/LyticsBridge.swift
@@ -56,16 +56,18 @@ public final class LyticsBridge: NSObject {
 
     // MARK: - Configuration
 
-    @objc(start:configuration:)
+    @objc(start:resolve:reject:)
     public func start(
-        apiToken: String,
-        configuration: [String: Any]?
+        configuration: [String: Any],
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
     ) {
-        lytics.start(apiToken: apiToken) { lyticsConfig in
-            guard let configuration, !configuration.isEmpty else {
-                return
-            }
+        guard let apiToken = configuration["apiToken"] as? String else {
+            reject("invalid_api_token", "Missing or Invalid API Token", nil)
+            return
+        }
 
+        lytics.start(apiToken: apiToken) { lyticsConfig in
             if let urlString = configuration["collectionEndpoint"] as? String,
                let collectionEndpoint = URL(string: urlString) {
                 lyticsConfig.collectionEndpoint = collectionEndpoint
@@ -136,6 +138,7 @@ public final class LyticsBridge: NSObject {
             if let defaultTable = configuration["defaultTable"] as? String {
                 lyticsConfig.defaultTable = defaultTable
             }
+            resolve(())
         }
     }
 

--- a/ios/LyticsBridge.swift
+++ b/ios/LyticsBridge.swift
@@ -202,35 +202,22 @@ public final class LyticsBridge: NSObject {
 
     // MARK: - Personalization
 
-    @objc(getProfile:reject:)
-    public func getProfile(
-        resolve: @escaping RCTPromiseResolveBlock,
-        reject: @escaping RCTPromiseRejectBlock
-    ) {
-        Task {
-            do {
-                let profile = try await lytics.getProfile()
-                let dictionary = try convert(profile)
-                resolve(dictionary)
-            } catch {
-                reject("failure", error.localizedDescription, error)
-            }
-        }
-    }
-
     @objc(getProfile:identifierValue:resolve:reject:)
     public func getProfile(
-        identifierName: String,
-        identifierValue: String,
+        identifierName: String?,
+        identifierValue: String?,
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock
     ) {
         Task {
             do {
-                let profile = try await lytics.getProfile(
-                    EntityIdentifier(
+                var identifier: EntityIdentifier?
+                if let identifierName, let identifierValue {
+                    identifier = EntityIdentifier(
                         name: identifierName,
-                        value: identifierValue))
+                        value: identifierValue)
+                }
+                let profile = try await lytics.getProfile(identifier)
                 let dictionary = try convert(profile)
                 resolve(dictionary)
             } catch {

--- a/ios/LyticsBridge.swift
+++ b/ios/LyticsBridge.swift
@@ -106,7 +106,6 @@ public final class LyticsBridge: NSObject {
                 lyticsConfig.sessionDuration = sessionDuration
             }
 
-            // TODO: do `Bool`s work as expected?
             if let enableSandbox = configuration["enableSandbox"] as? Bool {
                 lyticsConfig.enableSandbox = enableSandbox
             }
@@ -115,15 +114,17 @@ public final class LyticsBridge: NSObject {
                 lyticsConfig.requireConsent = requireConsent
             }
 
-            if let logLevel = configuration["logLevel"] as? String {
+            if let logLevel = configuration["logLevel"] as? Int {
                 switch logLevel {
-                case "debug":
+                // .verbose, .debug
+                case 0, 1:
                     lyticsConfig.logLevel = .debug
-                case "info":
+                case 2:
                     lyticsConfig.logLevel = .info
-                case "error":
+                // .warning, .error
+                case 3, 4:
                     lyticsConfig.logLevel = .error
-                case "none":
+                case 5:
                     lyticsConfig.logLevel = .none
                 default:
                     break

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,6 @@ export type LyticsConfiguration = {
   defaultStream?: string;
   primaryIdentityKey?: string;
   anonymousIdentityKey?: string;
-  trackApplicationLifecycleEvents?: boolean;
   uploadInterval?: number;
   maxQueueSize?: number;
   maxLoadRetryAttempts?: number;
@@ -44,6 +43,14 @@ export type LyticsConfiguration = {
   requireConsent?: boolean;
   logLevel?: LogLevel;
   defaultTable?: string;
+
+  // Andriod-only properties
+  autoTrackActivityScreens?: boolean;
+  autoTrackAppOpens?: boolean;
+  autoTrackFragmentScreens?: boolean;
+
+  // iOS-only properties
+  trackApplicationLifecycleEvents?: boolean;
 };
 
 export type JSONValue =
@@ -90,6 +97,7 @@ export function start(apiToken: string, options: LyticsConfiguration) {
 }
 
 // Events
+
 export interface TrackParams {
   stream?: string;
   name?: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -166,8 +166,10 @@ export type EntityIdentifier = {
   value: string;
 };
 
-export function getProfile(identifier?: EntityIdentifier): Promise<LyticsUser> {
-  return Sdk.getProfile(identifier?.name, identifier?.value);
+export function getProfile(
+  entityIdentifier?: EntityIdentifier
+): Promise<LyticsUser> {
+  return Sdk.getProfile(entityIdentifier?.name, entityIdentifier?.value);
 }
 
 // Tracking

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,11 +58,6 @@ export type JSONMap = {
   [key: string]: JSONValue;
 };
 
-export type EntityIdentifier = {
-  name: string;
-  value: string;
-};
-
 export type LyticsUser = {
   identifiers: JSONMap;
   attributes: JSONMap;
@@ -144,4 +139,26 @@ export interface ScreenParams {
 
 export function screen(params: ScreenParams) {
   Sdk.screen(params.stream, params.name, params.identifiers, params.properties);
+}
+
+// Personalization
+
+export type EntityIdentifier = {
+  name: string;
+  value: string;
+};
+
+export function getProfile(identifier?: EntityIdentifier): Promise<LyticsUser> {
+  return new Promise((resolve, reject) => {
+    if (identifier) {
+      Sdk.getProfileByIdentifier(
+        identifier.name,
+        identifier.value,
+        resolve,
+        reject
+      );
+    } else {
+      Sdk.getProfile(resolve, reject);
+    }
+  });
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,6 +44,25 @@ export type LyticsConfiguration = {
   defaultTable?: string;
 };
 
+export type JSONValue = boolean | number | string | null | JSONArray | JSONMap;
+
+export interface JSONMap {
+  [key: string]: JSONValue;
+}
+
+export type JSONArray = Array<JSONValue>;
+
+export type EntityIdentifier = {
+  name: string;
+  value: string;
+};
+
+export type LyticsUser = {
+  identifiers: JSONMap;
+  attributes: JSONMap;
+  profile: JSONMap;
+};
+
 // Properties
 
 export function hasStarted(): Promise<boolean> {
@@ -58,4 +77,65 @@ export type LyticsConfiguration = {
 
 export function start(apiToken: string, options: LyticsConfiguration) {
   Sdk.start(apiToken, options);
+}
+
+// Events
+export interface TrackParams {
+  stream?: string;
+  name?: string;
+  identifiers?: JSONMap;
+  properties?: JSONMap;
+}
+
+export function track(params: TrackParams) {
+  Sdk.track(params.stream, params.name, params.identifiers, params.properties);
+}
+
+export interface IdentifyParams {
+  stream?: string;
+  name?: string;
+  identifiers?: JSONMap;
+  attributes?: JSONMap;
+  shouldSend?: boolean;
+}
+
+export function identify(params: IdentifyParams) {
+  Sdk.identify(
+    params.stream,
+    params.name,
+    params.identifiers,
+    params.attributes,
+    params.shouldSend ?? true
+  );
+}
+
+export interface ConsentParams {
+  stream?: string;
+  name?: string;
+  identifiers?: JSONMap;
+  attributes?: JSONMap;
+  consent?: JSONMap;
+  shouldSend?: boolean;
+}
+
+export function consent(params: ConsentParams) {
+  Sdk.consent(
+    params.stream,
+    params.name,
+    params.identifiers,
+    params.attributes,
+    params.consent,
+    params.shouldSend ?? true
+  );
+}
+
+export interface ScreenParams {
+  stream?: string;
+  name?: string;
+  identifiers?: JSONMap;
+  properties?: JSONMap;
+}
+
+export function screen(params: ScreenParams) {
+  Sdk.screen(params.stream, params.name, params.identifiers, params.properties);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,33 @@ const Sdk = NativeModules.LyticsBridge
       }
     );
 
+// Types
+
+export enum LogLevel {
+  error,
+  warning,
+  info,
+  debug,
+}
+
+export type LyticsConfiguration = {
+  collectionEndpoint?: URL;
+  entityEndpoint?: URL;
+  defaultStream?: string;
+  primaryIdentityKey?: string;
+  anonymousIdentityKey?: string;
+  trackApplicationLifecycleEvents?: boolean;
+  uploadInterval?: number;
+  maxQueueSize?: number;
+  maxLoadRetryAttempts?: number;
+  maxUploadRetryAttempts?: number;
+  sessionDuration?: number;
+  enableSandbox?: boolean;
+  requireConsent?: boolean;
+  logLevel?: LogLevel;
+  defaultTable?: string;
+};
+
 // Properties
 
 export function hasStarted(): Promise<boolean> {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -158,18 +158,8 @@ export type EntityIdentifier = {
 };
 
 export function getProfile(identifier?: EntityIdentifier): Promise<LyticsUser> {
-  return new Promise((resolve, reject) => {
-    if (identifier) {
-      Sdk.getProfileByIdentifier(
-        identifier.name,
-        identifier.value,
-        resolve,
-        reject
-      );
-    } else {
-      Sdk.getProfile(resolve, reject);
-    }
-  });
+  return Sdk.getProfile(identifier?.name, identifier?.value);
+}
 
 // Tracking
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,13 +46,17 @@ export type LyticsConfiguration = {
   defaultTable?: string;
 };
 
-export type JSONValue = boolean | number | string | null | JSONArray | JSONMap;
+export type JSONValue =
+  | boolean
+  | number
+  | string
+  | null
+  | JSONValue[]
+  | JSONMap;
 
-export interface JSONMap {
+export type JSONMap = {
   [key: string]: JSONValue;
-}
-
-export type JSONArray = Array<JSONValue>;
+};
 
 export type EntityIdentifier = {
   name: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,6 +71,17 @@ export function hasStarted(): Promise<boolean> {
   return Sdk.hasStarted();
 }
 
+export function isOptedIn(): Promise<boolean> {
+  return Sdk.isOptedIn();
+}
+
+export function isTrackingEnabled(): Promise<boolean> {
+  return Sdk.isTrackingEnabled();
+}
+
+export function user(): Promise<LyticsUser> {
+  return Sdk.user();
+}
 
 // Configuration
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,9 +59,10 @@ export type JSONMap = {
 };
 
 export type LyticsUser = {
-  identifiers: JSONMap;
-  attributes: JSONMap;
-  profile: JSONMap;
+  identifiers?: JSONMap;
+  attributes?: JSONMap;
+  consent?: JSONMap;
+  profile?: JSONMap;
 };
 
 // Properties

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ export enum LogLevel {
 }
 
 export type LyticsConfiguration = {
+  apiToken: string;
   collectionEndpoint?: URL;
   entityEndpoint?: URL;
   defaultStream?: string;
@@ -92,8 +93,8 @@ export function user(): Promise<LyticsUser> {
 
 // Configuration
 
-export function start(apiToken: string, options: LyticsConfiguration) {
-  Sdk.start(apiToken, options);
+export function start(configuration: LyticsConfiguration): Promise<void> {
+  return Sdk.start(configuration);
 }
 
 // Events

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,11 +70,8 @@ export function hasStarted(): Promise<boolean> {
   return Sdk.hasStarted();
 }
 
-// Configuration
 
-export type LyticsConfiguration = {
-  [key: string]: any;
-};
+// Configuration
 
 export function start(apiToken: string, options: LyticsConfiguration) {
   Sdk.start(apiToken, options);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,10 +20,12 @@ const Sdk = NativeModules.LyticsBridge
 // Types
 
 export enum LogLevel {
-  error,
-  warning,
-  info,
+  verbose,
   debug,
+  info,
+  warning,
+  error,
+  none,
 }
 
 export type LyticsConfiguration = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -170,4 +170,35 @@ export function getProfile(identifier?: EntityIdentifier): Promise<LyticsUser> {
       Sdk.getProfile(resolve, reject);
     }
   });
+
+// Tracking
+
+export function optIn() {
+  Sdk.optIn();
+}
+
+export function optOut() {
+  Sdk.optOut();
+}
+
+export function requestTrackingAuthorization(): Promise<boolean> {
+  return Sdk.requestTrackingAuthorization();
+}
+
+export function disableTracking() {
+  Sdk.disableTracking();
+}
+
+// Utility
+
+export function identifier(): Promise<string> {
+  return Sdk.identifier();
+}
+
+export function dispatch() {
+  Sdk.dispatch();
+}
+
+export function reset() {
+  Sdk.reset();
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
+    "strictNullChecks": true,
     "target": "esnext",
     "verbatimModuleSyntax": true
   }


### PR DESCRIPTION
Adds a TypeScript interface for the SDK and uses it in the example app.

Additional:

- Android and iOS Change: use single `getProfile(...)` method with optional identifier and value params
- Android and iOS Fix: treat LogLevel as `Int`
- Android FIx: convert `LyticsUser` to `ReadableMap` rather than `HashMap`
- Example App: fix duplicate navigation name warning