### PR TITLE
Native Bridge Improvements

### DIFF
--- a/android/src/main/java/com/lytics/react_native/LyticsModule.kt
+++ b/android/src/main/java/com/lytics/react_native/LyticsModule.kt
@@ -1,6 +1,7 @@
 package com.lytics.react_native
 
 import android.content.Context
+import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -14,13 +15,14 @@ import com.lytics.android.logging.LogLevel
 import com.lytics.android.Lytics
 import com.lytics.android.LyticsConfiguration
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 class LyticsModule(reactContext: ReactApplicationContext) :
-    ReactContextBaseJavaModule(reactContext) {
+    ReactContextBaseJavaModule(reactContext), LifecycleEventListener {
 
     private val context: Context
 
@@ -28,10 +30,23 @@ class LyticsModule(reactContext: ReactApplicationContext) :
 
     init {
         context = reactContext.applicationContext
+        reactContext.addLifecycleEventListener(this)
     }
 
     override fun getName(): String {
         return NAME
+    }
+
+    override fun onHostResume() {
+        // noop - overridden to implement `LifecycleEventListener`
+    }
+
+    override fun onHostPause() {
+        // noop - overridden to implement `LifecycleEventListener`
+    }
+
+    override fun onHostDestroy() {
+        scope.cancel()
     }
 
     // Properties

--- a/android/src/main/java/com/lytics/react_native/LyticsModule.kt
+++ b/android/src/main/java/com/lytics/react_native/LyticsModule.kt
@@ -206,12 +206,16 @@ class LyticsModule(reactContext: ReactApplicationContext) :
     // Personalization
 
     @ReactMethod
-    fun getProfile(name: String? = null, value: String? = null, promise: Promise) {
+    fun getProfile(
+        identifierName: String? = null,
+        identifierValue: String? = null,
+        promise: Promise
+    ) {
         var identifier: EntityIdentifier? = null
-        if (name != null && value != null) {
+        if (identifierName != null && identifierValue != null) {
             identifier = EntityIdentifier(
-                name = name,
-                value = value
+                name = identifierName,
+                value = identifierValue
             )
         }
         scope.launch {

--- a/ios/LyticsBridge.mm
+++ b/ios/LyticsBridge.mm
@@ -13,22 +13,22 @@
 #pragma mark - Properties
 
 RCT_EXTERN_METHOD(hasStarted:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                  rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(isOptedIn:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                  rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(isTrackingEnabled:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                  rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(user:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                  rejecter:(RCTPromiseRejectBlock)reject)
 
 #pragma mark - Configuration
 
 RCT_EXTERN_METHOD(start:(NSDictionary<NSString *,id> *) configuration
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 
 #pragma mark - Events
 
@@ -60,8 +60,8 @@ RCT_EXTERN_METHOD(screen:(NSString *) stream
 
 RCT_EXTERN_METHOD(getProfile:(NSString *) identifierName
                   identifierValue:(NSString *) identifierValue
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 
 #pragma mark - Tracking
 
@@ -70,14 +70,14 @@ RCT_EXTERN_METHOD(optIn)
 RCT_EXTERN_METHOD(optOut)
 
 RCT_EXTERN_METHOD(requestTrackingAuthorization:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                  rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(disableTracking)
 
 #pragma mark - Utility
 
 RCT_EXTERN_METHOD(identifier:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
+                  rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(dispatch)
 

--- a/ios/LyticsBridge.swift
+++ b/ios/LyticsBridge.swift
@@ -23,25 +23,34 @@ public final class LyticsBridge: NSObject {
 
     // MARK: - Properties
 
-    @objc(hasStarted:reject:)
-    public func hasStarted(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    @objc(hasStarted:rejecter:)
+    public func hasStarted(
+        resolver resolve: RCTPromiseResolveBlock,
+        rejecter reject: RCTPromiseRejectBlock
+    ) {
         resolve(lytics.hasStarted)
     }
 
-    @objc(isOptedIn:reject:)
-    public func isOptedIn(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    @objc(isOptedIn:rejecter:)
+    public func isOptedIn(
+        resolver resolve: RCTPromiseResolveBlock,
+        rejecter reject: RCTPromiseRejectBlock
+    ) {
         resolve(lytics.isOptedIn)
     }
 
-    @objc(isTrackingEnabled:reject:)
-    public func isTrackingEnabled(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    @objc(isTrackingEnabled:rejecter:)
+    public func isTrackingEnabled(
+        resolver resolve: RCTPromiseResolveBlock,
+        rejecter reject: RCTPromiseRejectBlock
+    ) {
         resolve(lytics.isIDFAEnabled)
     }
 
-    @objc(user:reject:)
+    @objc(user:rejecter:)
     public func user(
-        resolve: @escaping RCTPromiseResolveBlock,
-        reject: @escaping RCTPromiseRejectBlock
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
         Task {
             let user = await lytics.user
@@ -56,11 +65,11 @@ public final class LyticsBridge: NSObject {
 
     // MARK: - Configuration
 
-    @objc(start:resolve:reject:)
+    @objc(start:resolver:rejecter:)
     public func start(
         configuration: [String: Any],
-        resolve: @escaping RCTPromiseResolveBlock,
-        reject: @escaping RCTPromiseRejectBlock
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
         guard let apiToken = configuration["apiToken"] as? String else {
             reject("invalid_api_token", "Missing or Invalid API Token", nil)
@@ -207,12 +216,12 @@ public final class LyticsBridge: NSObject {
 
     // MARK: - Personalization
 
-    @objc(getProfile:identifierValue:resolve:reject:)
+    @objc(getProfile:identifierValue:resolver:rejecter:)
     public func getProfile(
         identifierName: String?,
         identifierValue: String?,
-        resolve: @escaping RCTPromiseResolveBlock,
-        reject: @escaping RCTPromiseRejectBlock
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
         Task {
             do {
@@ -243,10 +252,10 @@ public final class LyticsBridge: NSObject {
         lytics.optOut()
     }
 
-    @objc(requestTrackingAuthorization:reject:)
+    @objc(requestTrackingAuthorization:rejecter:)
     public func requestTrackingAuthorization(
-        resolve: @escaping RCTPromiseResolveBlock,
-        reject: @escaping RCTPromiseRejectBlock
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
         Task {
             resolve(await lytics.requestTrackingAuthorization())
@@ -260,10 +269,10 @@ public final class LyticsBridge: NSObject {
 
     // MARK: - Utility
 
-    @objc(identifier:reject:)
+    @objc(identifier:rejecter:)
     public func identifier(
-        resolve: @escaping RCTPromiseResolveBlock,
-        reject: @escaping RCTPromiseRejectBlock
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
         resolve(lytics.identifier())
     }

--- a/ios/LyticsBridge.swift
+++ b/ios/LyticsBridge.swift
@@ -146,8 +146,8 @@ public final class LyticsBridge: NSObject {
 
     @objc(track:name:identifiers:properties:)
     public func track(
-        stream: String? = nil,
-        name: String? = nil,
+        stream: String?,
+        name: String?,
         identifiers: [String: Any],
         properties: [String: Any]
     ) {
@@ -160,8 +160,8 @@ public final class LyticsBridge: NSObject {
 
     @objc(identify:name:identifiers:attributes:shouldSend:)
     public func identify(
-        stream: String? = nil,
-        name: String? = nil,
+        stream: String?,
+        name: String?,
         identifiers: [String: Any],
         attributes: [String: Any],
         shouldSend: Bool = true
@@ -176,8 +176,8 @@ public final class LyticsBridge: NSObject {
 
     @objc(consent:name:identifiers:attributes:consent:shouldSend:)
     public func consent(
-        stream: String? = nil,
-        name: String? = nil,
+        stream: String?,
+        name: String?,
         identifiers: [String: Any],
         attributes: [String: Any],
         consent: [String: Any],
@@ -193,8 +193,8 @@ public final class LyticsBridge: NSObject {
 
     @objc(screen:name:identifiers:properties:)
     public func screen(
-        stream: String? = nil,
-        name: String? = nil,
+        stream: String?,
+        name: String?,
         identifiers: [String: Any],
         properties: [String: Any]
     ) {


### PR DESCRIPTION
Minor Improvements to native bridges

## Android

- conform to `LifecycleEventListener` to support cancellation of coroutine scope 
- change `getProfile` parameter names to match iOS

## iOS

- change method parameter names to match what seems to be the standard
- remove  default `nil` values