### PR TITLE
Quick Workflow Fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
   "engines": {
     "node": ">= 16.0.0"
   },
-  "packageManager": "^yarn@1.22.15",
   "jest": {
     "preset": "react-native",
     "modulePathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   "engines": {
     "node": ">= 16.0.0"
   },
+  "packageManager": "^yarn@1.22.21",
   "jest": {
     "preset": "react-native",
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
The current workflows fail with the following error:

```
Run yarn install --cwd example --frozen-lockfile
  yarn install --cwd example --frozen-lockfile
  yarn install --frozen-lockfile
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
error This project's package.json defines "packageManager": "yarn@^yarn@1.22.15". However the current global version of Yarn is 1.22.21.
```

This changes the specified `packageManager` version in `package.json` to try to get the tests to work.

Also adds a manual trigger to the workflow.
