### PR TITLE
Bump Version and Dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,6 +83,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
+def lytics_android_version = getExtOrDefault("lyticsAndroidVersion")
 
 dependencies {
   // For < 0.71, this will be from the local maven repo
@@ -90,7 +91,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  // FIXME: specify stable version
-  implementation 'com.github.lytics:android-sdk:main-SNAPSHOT'
+  implementation "com.github.lytics:android-sdk:$lytics_android_version"
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,3 +3,4 @@ Sdk_minSdkVersion=21
 Sdk_targetSdkVersion=31
 Sdk_compileSdkVersion=31
 Sdk_ndkversion=21.4.7075529
+Sdk_lyticsAndroidVersion=main-SNAPSHOT

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Sdk_minSdkVersion=21
 Sdk_targetSdkVersion=31
 Sdk_compileSdkVersion=31
 Sdk_ndkversion=21.4.7075529
-Sdk_lyticsAndroidVersion=main-SNAPSHOT
+Sdk_lyticsAndroidVersion=0.9.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-lytics",
-  "version": "0.0.1",
+  "version": "0.9.0",
   "description": "Lytics SDK for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-lytics.podspec
+++ b/react-native-lytics.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency "LyticsSDK"
+  s.dependency "LyticsSDK", "~> 0.9.0"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
Bumps the React Native SDK version to `0.9.0` and specifies the corresponding Android and iOS SDK versions.

- iOS: uses the [`~>` operator](https://guides.cocoapods.org/syntax/podfile.html#pod) to specify a range of versions from `0.9.0` up to but excluding `0.10.0`
- Android: specifies `0.9.0`

This also moves the definition of the Android SDK version from `android/build.gradle` to `android/gradle.properties`, where other dependency versions are specified.

**NOTE:** this should not be merged until the new Android and iOS releases are created.